### PR TITLE
Bug in the settings window

### DIFF
--- a/src/settingwindow.cpp
+++ b/src/settingwindow.cpp
@@ -1,6 +1,6 @@
 #include "settingwindow.h"
 #include "ui_settingwindow.h"
-
+#include <iostream>
 
 SettingWindow::SettingWindow(QWidget *parent) :
     QDialog(parent),
@@ -86,9 +86,10 @@ void SettingWindow::dump_config_attributes(Configuraion configuration)
     }
     else
     {
+        std::cout<<"Executing this option" << "\n";
         ui->checkBox_highlight->setChecked(false);
-        ui->lineEdit_specia_words_dir->setDisabled(false);
-        ui->pushButton_select_sw_dir->setDisabled(false);
+        ui->lineEdit_specia_words_dir->setDisabled(true);
+        ui->pushButton_select_sw_dir->setDisabled(true);
     }
 
 }


### PR DESCRIPTION
Hello
I just changed arguments in methods in settingwindow.cpp -> SettingWindow::dump_config_attributes from "false" to "true"


![Zrzut ekranu z 2022-07-20 12-10-40(1)](https://user-images.githubusercontent.com/104023013/179959998-93f698c7-389c-42a0-bb7d-64cd64272da7.png)


