### PR TITLE
Adding feature, which allows user to set image as textEdit background

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ set(PROJECT_SOURCES
         configuration.h
         filemanager.h src/filemanager.cpp
         Resources.qrc
+        loadbackgrounddialog.h src/loadbackgrounddialog.cpp
 )
 
 if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)

--- a/configuration.h
+++ b/configuration.h
@@ -6,7 +6,7 @@
 #include <vector>
 #include <filemanager.h>
 #include <wordprocessor.h>
-#define NUMBER_OF_ITEMS 5
+#define NUMBER_OF_ITEMS 6
 
 struct Configuraion
 {
@@ -14,6 +14,7 @@ struct Configuraion
     int default_font_size;
     int startup_behaviour;
     QString special_words_directory;
+    QString background_directory;
     QString last_Opened_File;
 
 
@@ -25,16 +26,18 @@ struct Configuraion
         startup_behaviour  = 0;
         special_words_directory = "-";
         last_Opened_File   = "-";
+        background_directory = "-";
     }
 
     //parametrized constructor
-    Configuraion(QString dfc, int dfs,  int strt, QString swd, QString lop)
+    Configuraion(QString dfc, int dfs,  int strt, QString swd, QString lop, QString bd)
     {
         default_font_color = dfc;
         default_font_size  = dfs;
         startup_behaviour  = strt;
         special_words_directory = swd;
         last_Opened_File   = lop;
+        background_directory = bd;
     }
 
     //Directory constructor
@@ -47,6 +50,7 @@ struct Configuraion
         this->startup_behaviour  = temp.startup_behaviour;
         this->special_words_directory = temp.special_words_directory;
         this->last_Opened_File   = temp.last_Opened_File;
+        this->background_directory = temp.background_directory;
     }
 
     static Configuraion loadConfiguraion(QString directory)
@@ -68,8 +72,9 @@ struct Configuraion
             int strt = stoi(lines[2].toStdString());
             QString swd = lines[3];
             QString lop = lines[4];
+            QString bd = lines[5];
 
-            return Configuraion(dfc,dfs,strt,swd,lop);
+            return Configuraion(dfc,dfs,strt,swd,lop,bd);
         }
         catch(...)
         {
@@ -86,6 +91,7 @@ struct Configuraion
         content += QString::fromStdString(std::to_string(config.startup_behaviour));        content+='\n';
         content += config.special_words_directory;                                          content+='\n';
         content += config.last_Opened_File;                                                 content+='\n';
+        content += config.background_directory;                                             content+='\n';
 
         return FileManager::writeToFile(directory, content);
     }
@@ -95,6 +101,26 @@ struct Configuraion
         return saveConfig(directory, config);
     }
 
+    std::string toString()
+    {
+        return default_font_color.toStdString() + "\n"
+        + std::to_string(default_font_size) + "\n"
+        + std::to_string(startup_behaviour) + "\n"
+        + special_words_directory.toStdString() + "\n"
+        + background_directory.toStdString() + "\n"
+        + last_Opened_File.toStdString() + "\n";
+    }
+
+    //comparison operator - checks if all field are equal
+    bool operator==(Configuraion& secondWin)
+    {
+        return(this->default_font_color == secondWin.default_font_color &&
+               this->default_font_size == secondWin.default_font_size && 
+               this->startup_behaviour == secondWin.startup_behaviour &&
+               this->special_words_directory == secondWin.special_words_directory &&
+               this->background_directory == secondWin.background_directory &&
+               this->last_Opened_File == secondWin.last_Opened_File);
+    } 
 };
 
 #endif // CONFIGURATION_H

--- a/loadbackgrounddialog.h
+++ b/loadbackgrounddialog.h
@@ -1,0 +1,23 @@
+#ifndef LOADBACKGROUNDDIALOG_H
+#define LOADBACKGROUNDDIALOG_H
+
+namespace Ui{
+    class LoadBackgroundDialog;
+}
+
+#include <QFileDialog>
+#include "filemanager.h"
+
+class LoadBackgroundDialog: public QFileDialog
+{
+    Q_OBJECT
+public:
+    LoadBackgroundDialog(QWidget * parent,
+                         QString caption,
+                         QString dir,
+                         QString filter);
+};
+
+
+
+#endif // LOADBACKGROUNDDIALOG_H

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -29,7 +29,7 @@ class MainWindow : public QMainWindow
 public:
     MainWindow(QWidget *parent = nullptr);
     ~MainWindow();
-    static Configuraion getCurrentConfiguration();
+    static Configuraion& getCurrentConfiguration();
 
 
 private slots:
@@ -69,7 +69,7 @@ private:
     void loadSpecialWords(QString);
     void openFile(QString);
     void setTextEditBgColor(QString);
-
+    void setTextEditBgImage(QString);
 protected:
     void timerEvent(QTimerEvent *event);
 };

--- a/settingwindow.h
+++ b/settingwindow.h
@@ -2,7 +2,10 @@
 #define SETTINGWINDOW_H
 
 #include "configuration.h"
+#include "filemanager.h"
 #include "mainwindow.h"
+#include "loadbackgrounddialog.h"
+//#include "cstdlib"
 #include <QDialog>
 
 namespace Ui {
@@ -28,11 +31,15 @@ private slots:
 
     void on_resetButton_clicked();
 
+    void on_pushButton_textEditBackground_clicked();
+
+    void on_checkBox_textEditBackground_stateChanged();
+
 private:
     Ui::SettingWindow *ui;
     void gather_config_attributes();
     void dump_config_attributes(Configuraion);
-
 };
 
 #endif // SETTINGWINDOW_H
+

--- a/src/loadbackgrounddialog.cpp
+++ b/src/loadbackgrounddialog.cpp
@@ -1,0 +1,11 @@
+#include "loadbackgrounddialog.h"
+#include <iostream>
+
+LoadBackgroundDialog::LoadBackgroundDialog(QWidget * parent,
+                                            QString caption,
+                                            QString dir,
+                                            QString filter)
+    :QFileDialog(parent, caption, dir, filter)
+{
+    ;
+}

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -27,7 +27,7 @@ MainWindow::~MainWindow()
 
 Configuraion MainWindow::currentConfiguration = Configuraion();
 
-Configuraion MainWindow::getCurrentConfiguration()
+Configuraion& MainWindow::getCurrentConfiguration()
 {
     return currentConfiguration;
 }
@@ -202,9 +202,15 @@ void MainWindow::applyConfiguration(Configuraion config)
         textEdit->setText("");
     }
 
-    //Special Words
+    //Did user set special_words_dir?
     if(config.special_words_directory[0]!='-')
         loadSpecialWords(config.special_words_directory);
+
+    //Sets white background if user didnt specified directory
+    //or left checkbox unchecked.
+    setTextEditBgImage(getCurrentConfiguration().background_directory);
+    
+
 }
 
 
@@ -213,12 +219,22 @@ void MainWindow::on_actionSettings_triggered()
     SettingWindow settingWindow;
     settingWindow.setModal(true);
     settingWindow.exec();
+    applyConfiguration(currentConfiguration);
 }
-
 
 void MainWindow::setTextEditBgColor(QString color)
 {
     ui->textEdit->setStyleSheet("background-color: "+ color + ";");
 }
 
-
+void MainWindow::setTextEditBgImage(QString path)
+{
+    if(path[0] != '-')
+    {
+        ui->textEdit->setStyleSheet("background-image:url(" + path + ");");
+    }
+    else
+    {
+        setTextEditBgColor(QString("white"));
+    }
+}

--- a/src/settingwindow.cpp
+++ b/src/settingwindow.cpp
@@ -1,6 +1,6 @@
 #include "settingwindow.h"
 #include "ui_settingwindow.h"
-#include <iostream>
+
 
 SettingWindow::SettingWindow(QWidget *parent) :
     QDialog(parent),
@@ -26,6 +26,25 @@ void SettingWindow::on_checkBox_highlight_stateChanged(int arg1)
     ui->pushButton_select_sw_dir->setDisabled(state);
 }
 
+void SettingWindow::on_checkBox_textEditBackground_stateChanged()
+{
+    //Updates user interface and configuration 
+    if(ui->checkBox_textEditBackground->isChecked())
+    {
+        tempConfig.background_directory = ui->lineEdit_textEditBackground->text();
+        ui->lable_textEditBackground->setDisabled(false);
+        ui->lineEdit_textEditBackground->setDisabled(false);
+        ui->pushButton_textEditBackground->setDisabled(false);
+    }
+    else
+    {
+        tempConfig.background_directory = "-";
+        ui->lable_textEditBackground->setDisabled(true);
+        ui->lineEdit_textEditBackground->setDisabled(true);
+        ui->pushButton_textEditBackground->setDisabled(true);
+    }
+}
+
 
 void SettingWindow::on_cancelButton_clicked()
 {
@@ -38,7 +57,7 @@ void SettingWindow::on_okButton_clicked()
     QString configPath = FileManager::get_config_path();
     gather_config_attributes();
     Configuraion::saveConfig(tempConfig);
-
+    MainWindow::getCurrentConfiguration() = tempConfig;
     close();
 }
 
@@ -57,8 +76,8 @@ void SettingWindow::gather_config_attributes()
         sWordsDir = ui->lineEdit_specia_words_dir->text();
 
     QString lastOpened = MainWindow::getCurrentConfiguration().last_Opened_File;
-
-    tempConfig = Configuraion(color,fSize, sBehaviour,sWordsDir,lastOpened);
+    
+    tempConfig = Configuraion(color,fSize, sBehaviour,sWordsDir,lastOpened, tempConfig.background_directory);
 }
 
 //Get Configuraion attributes and selecte them in the UI
@@ -86,17 +105,39 @@ void SettingWindow::dump_config_attributes(Configuraion configuration)
     }
     else
     {
-        std::cout<<"Executing this option" << "\n";
         ui->checkBox_highlight->setChecked(false);
         ui->lineEdit_specia_words_dir->setDisabled(true);
         ui->pushButton_select_sw_dir->setDisabled(true);
     }
 
+    //Is background directory specified?
+    if(configuration.background_directory[0]!='-')
+    {
+        ui->checkBox_textEditBackground->setChecked(true);
+        ui->checkBox_textEditBackground->setDisabled(false);
+        ui->lineEdit_textEditBackground->setText(configuration.background_directory);
+    }
+    else
+    {
+        ui->checkBox_textEditBackground->setChecked(false);
+        ui->lineEdit_textEditBackground->setDisabled(true);
+        ui->pushButton_textEditBackground->setDisabled(true);
+    }
 }
 //reset settings to default: use default constructor of Configuration class
 void SettingWindow::on_resetButton_clicked()
 {
     tempConfig = Configuraion();
     dump_config_attributes(tempConfig);
+}
+
+void SettingWindow::on_pushButton_textEditBackground_clicked()
+{
+    QString homeDir = FileManager::get_homedir(),
+            caption = QString("Load background"),
+            filter = QString("All files (*.*);;JPEG (*.jpg *.jpeg);;TIFF (*.tif);;BMP (*.bmp)");
+    LoadBackgroundDialog myLoadBackgroundDialog(this, caption, homeDir, filter);
+    tempConfig.background_directory = myLoadBackgroundDialog.getOpenFileName();
+    ui->lineEdit_textEditBackground->setText(tempConfig.background_directory);
 }
 

--- a/src/settingwindow.ui
+++ b/src/settingwindow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>596</width>
-    <height>358</height>
+    <height>430</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,7 +17,7 @@
    <property name="geometry">
     <rect>
      <x>410</x>
-     <y>310</y>
+     <y>390</y>
      <width>80</width>
      <height>25</height>
     </rect>
@@ -30,7 +30,7 @@
    <property name="geometry">
     <rect>
      <x>500</x>
-     <y>310</y>
+     <y>390</y>
      <width>80</width>
      <height>25</height>
     </rect>
@@ -229,7 +229,7 @@
    <property name="geometry">
     <rect>
      <x>20</x>
-     <y>310</y>
+     <y>390</y>
      <width>111</width>
      <height>25</height>
     </rect>
@@ -267,6 +267,61 @@
    </property>
    <property name="text">
     <string>Auto highlight special words</string>
+   </property>
+  </widget>
+  <widget class="QCheckBox" name="checkBox_textEditBackground">
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>290</y>
+     <width>391</width>
+     <height>23</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Custom text editor background</string>
+   </property>
+  </widget>
+  <widget class="QLineEdit" name="lineEdit_textEditBackground">
+   <property name="enabled">
+    <bool>true</bool>
+   </property>
+   <property name="geometry">
+    <rect>
+     <x>210</x>
+     <y>330</y>
+     <width>201</width>
+     <height>25</height>
+    </rect>
+   </property>
+  </widget>
+  <widget class="QPushButton" name="pushButton_textEditBackground">
+   <property name="geometry">
+    <rect>
+     <x>420</x>
+     <y>330</y>
+     <width>21</width>
+     <height>25</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>...</string>
+   </property>
+  </widget>
+  <widget class="QLabel" name="lable_textEditBackground">
+   <property name="enabled">
+    <bool>true</bool>
+   </property>
+   <property name="geometry">
+    <rect>
+     <x>20</x>
+     <y>330</y>
+     <width>141</width>
+     <height>17</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Background source file</string>
    </property>
   </widget>
  </widget>


### PR DESCRIPTION
This PR refers to https://github.com/Khaled-Waled/NotaPadQT/issues/8

changes:
- adding new field in class **Configuration** named **background_directory**
- changing  constructors and methods in  **Configuration** class to work with new attribute
- adding 2 new methods that can be useful in future
- adding new class **LoadBackgroundDialog** modifying **MainWindow** and **SettingWindow** methods to work with new feature
- changing SettingWindow user interface
- **MainWindow::getCurrentConfiguration()** now returns  **Configuraion&** instead of **Configuraion**
 